### PR TITLE
src: Implement an Address Space Controller(ASC)

### DIFF
--- a/src/asc.rs
+++ b/src/asc.rs
@@ -1,0 +1,63 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+pub trait MemoryMapped {
+    fn write(&mut self, addr: u16, value: u8);
+
+    fn read(&mut self, addr: u16) -> u8;
+}
+
+pub struct Asc {
+    devices: HashMap<u16, Rc<RefCell<dyn MemoryMapped>>>,
+}
+
+impl Asc {
+    pub fn new() -> Asc {
+        Asc {
+            devices: HashMap::new(),
+        }
+    }
+
+    pub fn register_device(&mut self, addr: u16, dev: Rc<RefCell<dyn MemoryMapped>>) {
+        self.devices.insert(addr, dev);
+    }
+
+    pub fn register_device_range(
+        &mut self,
+        addrs: impl Iterator<Item = u16>,
+        dev: Rc<RefCell<dyn MemoryMapped>>,
+    ) {
+        for addr in addrs {
+            self.devices.insert(addr, dev.clone());
+        }
+    }
+}
+
+impl MemoryMapped for Asc {
+    fn write(&mut self, addr: u16, value: u8) {
+        self.devices
+            .get_mut(&addr)
+            .unwrap_or_else(|| {
+                panic!(
+                    "tried to write value {:#x} to address {:#x} that no device is registred",
+                    value, addr
+                )
+            })
+            .borrow_mut()
+            .write(addr, value);
+    }
+
+    fn read(&mut self, addr: u16) -> u8 {
+        self.devices
+            .get_mut(&addr)
+            .unwrap_or_else(|| {
+                panic!(
+                    "tried to read from address {:#x} that no device is registred",
+                    addr
+                )
+            })
+            .borrow_mut()
+            .read(addr)
+    }
+}

--- a/src/ram.rs
+++ b/src/ram.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use crate::asc::MemoryMapped;
+
 #[derive(Debug, Default)]
 pub struct Ram {
     memory: HashMap<u16, u8>,
@@ -17,12 +19,14 @@ impl Ram {
             self.write(a as u16 + offset, v);
         }
     }
+}
 
-    pub fn write(&mut self, addr: u16, value: u8) {
+impl MemoryMapped for Ram {
+    fn write(&mut self, addr: u16, value: u8) {
         self.memory.insert(addr, value);
     }
 
-    pub fn read(&self, addr: u16) -> u8 {
+    fn read(&mut self, addr: u16) -> u8 {
         let x = self.memory.get(&addr).unwrap_or(&0);
         return *x;
     }


### PR DESCRIPTION
Many of the PPU actions are governed by writes and reads to specific addresses. Currently, we can't have code triggered by a write or read to a specific address.

Implement an Address Space Controller(ASC) to handle writes and reads to an address space, and with that, redirect the access to specific addresses to Ppu variables.

Fix #8