### PR TITLE
Change the project name to "Rodomo"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "emulator"
+name = "rodomo"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NES-emulator
+# Rodomo
 
 > [!WARNING]
 > This software is unfinished. Keep your expectations low.


### PR DESCRIPTION
After very long time thinking with my girlfriend about what would be the name of this emulator, we found a suitable name.

This name comes from the Portuguese phrase "Rodou, mo!", the literal translation is "It worked, love!". I always say this to my girlfriend when something works on the emulator.

Fix #7